### PR TITLE
Fix PaymentActivity layout

### DIFF
--- a/SamplePay/app/src/main/res/layout/payment_activity.xml
+++ b/SamplePay/app/src/main/res/layout/payment_activity.xml
@@ -14,22 +14,20 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
 -->
-<ScrollView
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/scroll"
+    android:id="@+id/payment"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
-    <androidx.coordinatorlayout.widget.CoordinatorLayout
-        android:id="@+id/payment"
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:fitsSystemWindows="true"
-        android:orientation="vertical">
-
+        android:layout_height="wrap_content">
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
@@ -37,7 +35,16 @@
             android:background="?attr/colorPrimary"
             android:elevation="@dimen/toolbar_elevation"
             android:theme="@style/ThemeOverlay.MaterialComponents.Dark.ActionBar"
+            app:layout_scrollFlags="scroll|enterAlways|snap"
             tools:targetApi="21" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/scroll"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/content"
@@ -321,6 +328,6 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+    </androidx.core.widget.NestedScrollView>
 
-</ScrollView>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
The PaymentActivity is supposed to show the merchant name and top level
origin but both text views are currently hidden behind the toolbar. This
fixes the layout by swapping the scroll view with the coordinator layout
to enable the correct scroll behaviour of the toolbar.

Before:
![before](https://user-images.githubusercontent.com/1607339/115227327-3ec76f80-a108-11eb-8024-fc39dc239f45.png)

After:
![after](https://user-images.githubusercontent.com/1607339/115227356-44bd5080-a108-11eb-84bb-2621cf5399f9.png)
