### PR TITLE
Support "googlequicksearchbox" (a WebLayer embedder)

### DIFF
--- a/SamplePay/app/src/main/java/com/example/android/samplepay/PackageManagerUtils.kt
+++ b/SamplePay/app/src/main/java/com/example/android/samplepay/PackageManagerUtils.kt
@@ -72,5 +72,7 @@ fun PackageManager.authorizeCaller(packageName: String?, context: Context): Bool
         packageName, setOf(parseFingerprint(context.getString(R.string.chrome_canary_fingerprint)))
     )) || (packageName == "org.chromium.chrome" && hasSigningCertificates(
         packageName, setOf(parseFingerprint(context.getString(R.string.chromium_fingerprint)))
-    ))
+    )) || (packageName == "com.google.android.googlequicksearchbox" && hasSigningCertificates(
+        packageName, setOf(parseFingerprint(context.getString(R.string.googlequicksearchbox_fingerprint))
+        )))
 }

--- a/SamplePay/app/src/main/res/values/strings.xml
+++ b/SamplePay/app/src/main/res/values/strings.xml
@@ -31,6 +31,7 @@
     <string name="chrome_dev_fingerprint" translatable="false">90:44:EE:5F:EE:4B:BC:5E:21:DD:44:66:54:31:C4:EB:1F:1F:71:A3:27:16:A0:BC:92:7B:CB:B3:92:33:CA:BF</string>
     <string name="chrome_canary_fingerprint" translatable="false">20:19:DF:A1:FB:23:EF:BF:70:C5:BC:D1:44:3C:5B:EA:B0:4F:3F:2F:F4:36:6E:9A:C1:E3:45:76:39:A2:4C:FC</string>
     <string name="chromium_fingerprint" translatable="false">32:A2:FC:74:D7:31:10:58:59:E5:A8:5D:F1:6D:95:F1:02:D8:5B:22:09:9B:80:64:C5:D8:91:5C:61:DA:D1:E0</string>
+    <string name="googlequicksearchbox_fingerprint">F0:FD:6C:5B:41:0F:25:CB:25:C3:B5:33:46:C8:97:2F:AE:30:F8:EE:74:11:DF:91:04:80:AD:6B:2D:60:DB:83</string>
     <string name="your_full_name">Your Full Name</string>
     <string name="your_phone_number">Your Phone Number</string>
     <string name="your_email_address">Your Email Address</string>


### PR DESCRIPTION
Google Quick Search Box[1], a WebLayer embedder, has started to support[2] Android payment app fully (including PaymentDetailsUpdateService) since version 12.19.9.23. This patch is to allowlist its package "com.google.android.googlequicksearchbox" so that the payment app can work with the search box app.

[1] https://play.google.com/store/apps/details?id=com.google.android.googlequicksearchbox
[2] https://chromium-review.googlesource.com/c/chromium/src/+/2844605/17/weblayer/public/java/AndroidManifest.xml