### PR TITLE
Expose the UPDATE_PAYMENT_DETAILS service.

### DIFF
--- a/SamplePay/app/src/main/AndroidManifest.xml
+++ b/SamplePay/app/src/main/AndroidManifest.xml
@@ -63,7 +63,7 @@
         </activity>
 
         <!--
-            The service should check the caller at runtime.
+            These services should check the caller at runtime.
         -->
         <service
             android:name=".SampleIsReadyToPayService"
@@ -72,6 +72,15 @@
             tools:ignore="ExportedService">
             <intent-filter>
                 <action android:name="org.chromium.intent.action.IS_READY_TO_PAY" />
+            </intent-filter>
+        </service>
+        <service
+            android:name=".SamplePaymentDetailsUpdateService"
+            android:enabled="true"
+            android:exported="true"
+            tools:ignore="ExportedService">
+            <intent-filter>
+                <action android:name="org.chromium.intent.action.UPDATE_PAYMENT_DETAILS" />
             </intent-filter>
         </service>
 

--- a/SamplePay/app/src/main/aidl/org/chromium/components/payments/IPaymentDetailsUpdateServiceCallback.aidl
+++ b/SamplePay/app/src/main/aidl/org/chromium/components/payments/IPaymentDetailsUpdateServiceCallback.aidl
@@ -2,6 +2,8 @@ package org.chromium.components.payments;
 
 import android.os.Bundle;
 
+import org.chromium.components.payments.IPaymentDetailsUpdateService;
+
 /**
  * Helper interface used by the browser to notify the invoked native app about
  * merchant's response to one of the paymentmethodchange, shippingoptionchange,
@@ -22,4 +24,16 @@ interface IPaymentDetailsUpdateServiceCallback {
      * modified the payment details.
      */
     oneway void paymentDetailsNotUpdated();
+
+    /**
+     * Called during a payment flow to point the payment app back to the payment
+     * details update service to invoke when the user changes the payment
+     * method, the shipping address, or the shipping option.
+     *
+     * @param service The payment details update service to invoke when the user
+     *      changes the payment method, the shipping address, or the shipping
+     *      option.
+     */
+    oneway void setPaymentDetailsUpdateService(
+            IPaymentDetailsUpdateService service);
 }

--- a/SamplePay/app/src/main/java/com/example/android/samplepay/SampleIsReadyToPayService.kt
+++ b/SamplePay/app/src/main/java/com/example/android/samplepay/SampleIsReadyToPayService.kt
@@ -37,11 +37,11 @@ class SampleIsReadyToPayService : Service() {
                 val callingPackage: String? = packageManager.getNameForUid(Binder.getCallingUid())
                 if (application.authorizeCaller(callingPackage)) {
                     Log.d(TAG, "The caller is Chrome")
-                    callback?.handleIsReadyToPay(true)
                 } else {
                     Log.d(TAG, "The caller is not Chrome")
-                    callback?.handleIsReadyToPay(false)
                 }
+                // Allow non-Chrome callers.
+                callback?.handleIsReadyToPay(true)
             } catch (e: RemoteException) {
                 // Ignore
             }

--- a/SamplePay/app/src/main/java/com/example/android/samplepay/SamplePaymentDetailsUpdateService.kt
+++ b/SamplePay/app/src/main/java/com/example/android/samplepay/SamplePaymentDetailsUpdateService.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.android.samplepay
+
+import android.app.Service
+import android.content.Intent
+import android.os.Binder
+import android.util.Log
+import com.example.android.samplepay.model.PaymentDetailsUpdate
+import org.chromium.components.payments.IPaymentDetailsUpdateService
+import org.chromium.components.payments.IPaymentDetailsUpdateServiceCallback
+
+private const val TAG = "PaymentDetailsUpdateService"
+
+/**
+ * This service handles the UPDATE_PAYMENT_DETAILS service connection from Chrome.
+ */
+class SamplePaymentDetailsUpdateService : Service() {
+
+    companion object {
+      var connectedService: IPaymentDetailsUpdateService?
+      var viewModel: PaymentViewModel?
+    }
+
+    private val binder = object : IPaymentDetailsUpdateServiceCallback.Stub() {
+        override fun paymentDetailsNotUpdated() {
+            Log.d("TAG", "Payment details did not change.")
+        }
+
+        override fun updateWith(newPaymentDetails: Bundle) {
+            Log.d("TAG", "Payment details changed.")
+            val update = PaymentDetailsUpdate.from(newPaymentDetails)
+            runOnUiThread {
+                update.shippingOptions?.let { viewModel.updateShippingOptions(it) }
+                update.total?.let { viewModel.updateTotal(it) }
+                viewModel.updateError(update.error ?: "")
+                update.addressErrors?.let { viewModel.updateAddressErrors(it) }
+                viewModel.updatePromotionError(update.stringifiedPaymentMethodErrors ?: "")
+            }
+        }
+
+        override fun setPaymentDetailsUpdateService(service: IPaymentDetailsUpdateService) {
+            Log.d("TAG", "Payment details service connected.")
+            connectedService = service;
+        }
+    }
+
+    override fun onBind(intent: Intent?) = binder
+}


### PR DESCRIPTION
Before this patch, this payment app connected to the `UPDATE_PAYMENT_DETAILS` service in Chrome for dynamic price updates. However, not all implementations of user agents can expose a service.

This patch:
1. Moves the implementation of `UPDATE_PAYMENT_DETAILS` service into its own class `SamplePaymentDetailsUpdateService` that is exposed from the payment app through `AndroidManifest.xml`, similar to `IS_READY_TO_PAY` service.
2. Connects the `PaymentActivity` and `SamplePaymentDetailsUpdateService` through static member variables in `SamplePaymentDetailsUpdateService`.
3. Allows non-Chrome callers into `SampleIsReadyToPayService`.

After this patch, user agents can connect to this payment app's `UPDATE_PAYMENT_DETAILS` service for dynamic price updates. Chrome supports connecting to the payment app's `UPDATE_PAYMENT_DETAILS` service since version 132.0.6807.0 behind the `chrome://flags/#enable-web-payments-experimental-features` flag ([patch](https://chromiumdash.appspot.com/commit/bd0f7c78bbc6895a2255b5e5a430a65cdece02b9)).