### PR TITLE
Include scenario where the caller does not support the UPDATE_PAYMENT_DETAILS service

### DIFF
--- a/SamplePay/app/src/main/java/com/example/android/samplepay/ui/PaymentApp.kt
+++ b/SamplePay/app/src/main/java/com/example/android/samplepay/ui/PaymentApp.kt
@@ -92,15 +92,15 @@ fun DefaultScreen(modifier: Modifier = Modifier) {
 }
 
 @Composable
-fun SecurityErrorDialog(openDialog: Boolean, onDismissed: () -> Unit) {
+fun SecurityErrorDialog(openDialog: Boolean, errorMessage: String, onDismissed: () -> Unit) {
     if (openDialog) {
         AlertDialog(title = {
-            Text(text = "Security error")
+            Text(text = stringResource(R.string.error))
         }, text = {
-            Text(text = "This payment app is being called by multiple applications, which is not supported by this provider.")
+            Text(text = errorMessage)
         }, onDismissRequest = onDismissed, dismissButton = {
             TextButton(onClick = onDismissed) {
-                Text("Dismiss")
+                Text(stringResource(R.string.dismiss))
             }
         }, confirmButton = {})
     }

--- a/SamplePay/app/src/main/java/com/example/android/samplepay/ui/PaymentApp.kt
+++ b/SamplePay/app/src/main/java/com/example/android/samplepay/ui/PaymentApp.kt
@@ -39,6 +39,7 @@ import com.example.android.samplepay.ui.theme.AppTheme
 fun PaymentApp(
     payIntent: PaymentIntent,
     openErrorDialog: Boolean,
+    errorMessage: String,
     onErrorDismissed: () -> Unit,
     onAddPromoCode: (String) -> Unit,
     onShippingOptionChange: (String) -> Unit,
@@ -56,7 +57,11 @@ fun PaymentApp(
                     onShippingAddressChange = onShippingAddressChange,
                     onPayButtonClicked = onPayButtonClicked
                 )
-                SecurityErrorDialog(openDialog = openErrorDialog, onDismissed = onErrorDismissed)
+                SecurityErrorDialog(
+                    openDialog = openErrorDialog,
+                    errorMessage = errorMessage,
+                    onDismissed = onErrorDismissed
+                )
             }
         }
     }

--- a/SamplePay/app/src/main/java/com/example/android/samplepay/ui/PaymentScreen.kt
+++ b/SamplePay/app/src/main/java/com/example/android/samplepay/ui/PaymentScreen.kt
@@ -264,7 +264,7 @@ private fun PaymentSummary(
                 .padding(horizontal = dimensionResource(R.dimen.spacing_medium))
                 .fillMaxWidth()
         ) {
-            Text("Pay")
+            Text(stringResource(R.string.pay))
         }
     }
 }
@@ -274,7 +274,7 @@ private fun AmountLabel(currency: String, value: String, modifier: Modifier = Mo
     Column(
         horizontalAlignment = Alignment.CenterHorizontally, modifier = modifier.fillMaxWidth()
     ) {
-        Text(text = "Total price:", style = Typography.labelLarge)
+        Text(text = stringResource(R.string.total_price), style = Typography.labelLarge)
         BasicText(
             text = stringResource(R.string.amount_label, currency, value),
             maxLines = 1,
@@ -402,7 +402,7 @@ fun ContactForm(
 
     Column(modifier = modifier.padding(horizontal = dimensionResource(R.dimen.spacing_medium))) {
         Text(
-            text = "Contact information",
+            text = stringResource(R.string.contact_information),
             style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.secondary
         )
@@ -412,7 +412,7 @@ fun ContactForm(
             PaymentFormTextField(
                 value = contactInfo.name,
                 label = {
-                    Text("Name")
+                    Text(stringResource(R.string.name))
                 },
                 onValueChange = {
                     contactInfo = contactInfo.copy(name = it)
@@ -426,7 +426,7 @@ fun ContactForm(
             Spacer(modifier = modifier.height(dimensionResource(R.dimen.spacing_small)))
             PaymentFormTextField(
                 value = contactInfo.phoneNumber, label = {
-                Text("Phone number")
+                Text(stringResource(R.string.phone_number))
             }, onValueChange = {
                 contactInfo = contactInfo.copy(phoneNumber = it)
                 onContactInfoChange(contactInfo)
@@ -437,7 +437,7 @@ fun ContactForm(
             Spacer(modifier = modifier.height(dimensionResource(R.dimen.spacing_small)))
             PaymentFormTextField(
                 value = contactInfo.emailAddress, label = {
-                Text("Email address")
+                Text(stringResource(R.string.email_address))
             }, onValueChange = {
                 contactInfo = contactInfo.copy(emailAddress = it)
                 onContactInfoChange(contactInfo)

--- a/SamplePay/app/src/main/res/values/strings.xml
+++ b/SamplePay/app/src/main/res/values/strings.xml
@@ -18,21 +18,20 @@
     <string name="app_name">SamplePay</string>
 
     <string name="home_explanation">This is a sample payment app. Use the SampleMerchant website (at https://sample-pay-ss.web.app/) to initiate a transaction.</string>
+    <string name="total_price">Total price:</string>
     <string name="total_format">Total: %1$s %2$s</string>
     <string name="amount_label">%1$s%2$s</string>
     <string name="payment_explanation">
         This is a sample payment app, and no actual payment will be processed.
     </string>
     <string name="pay">Pay</string>
-    <string name="error_caller_not_chrome">The caller is not Chrome.</string>
-    <string name="chrome_stable_fingerprint" translatable="false">F0:FD:6C:5B:41:0F:25:CB:25:C3:B5:33:46:C8:97:2F:AE:30:F8:EE:74:11:DF:91:04:80:AD:6B:2D:60:DB:83</string>
-    <string name="chrome_beta_fingerprint" translatable="false">DA:63:3D:34:B6:9E:63:AE:21:03:B4:9D:53:CE:05:2F:C5:F7:F3:C5:3A:AB:94:FD:C2:A2:08:BD:FD:14:24:9C</string>
-    <string name="chrome_dev_fingerprint" translatable="false">90:44:EE:5F:EE:4B:BC:5E:21:DD:44:66:54:31:C4:EB:1F:1F:71:A3:27:16:A0:BC:92:7B:CB:B3:92:33:CA:BF</string>
-    <string name="chrome_canary_fingerprint" translatable="false">20:19:DF:A1:FB:23:EF:BF:70:C5:BC:D1:44:3C:5B:EA:B0:4F:3F:2F:F4:36:6E:9A:C1:E3:45:76:39:A2:4C:FC</string>
-    <string name="chromium_fingerprint" translatable="false">32:A2:FC:74:D7:31:10:58:59:E5:A8:5D:F1:6D:95:F1:02:D8:5B:22:09:9B:80:64:C5:D8:91:5C:61:DA:D1:E0</string>
-    <string name="your_full_name">Your Full Name</string>
-    <string name="your_phone_number">Your Phone Number</string>
-    <string name="your_email_address">Your Email Address</string>
+    <string name="error">Error</string>
+    <string name="dismiss">Dismiss</string>
+    <string name="error_multiple_callers">"This payment app is being called by multiple applications, which is not supported by this provider."</string>
+    <string name="error_caller_not_supported">The caller does not support a payments update service, which is required by this payment application.</string>
+    <string name="name">Name</string>
+    <string name="phone_number">Phone number</string>
+    <string name="email_address">Email address</string>
     <string name="payment_response">paymentActivityResponse</string>
     <string name="title_activity_payment_details_update">PaymentDetailsUpdate</string>
     <string name="us_address">US address</string>


### PR DESCRIPTION
- Add a new exception to capture cases when the calling Web engine does not support the UPDATE_PAYMENT_DETAILS service
- Remove all hardcoded strings in favor of string resources